### PR TITLE
Disable default stderr handling

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -103,6 +103,7 @@ class Gcc(Linter):
 
     # SublimeLinter capture settings
     executable = None
+    on_stderr = None  # handle stderr via split_match
     multiline = True
     syntax = list(c_syntaxes | cpp_syntaxes)
     regex = (


### PR DESCRIPTION
This plugin implicitly claims stdout and stderr handling. SL 4.3 has a built-in callback for such linters. 

Since for this linter the actual lint errors to parse are on stderr, we either need to disable the standard handling, like proposed, or switch `error_stream = util.STREAM_STDERR`. 

Whatever we do, the plugin should in-the-long-run report configuration and other hard errors to the user using `self.notify_failure()`.