### PR TITLE
Adapt to new SL api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # SublimeLinter-gcc
 
 
+## 1.4.0
+
+- Make two separated linters (as for sublimelinter-clang) and adapt to new sublime linter API
+
 ## 1.3.9
 
 - Fix a typo.

--- a/README.md
+++ b/README.md
@@ -62,9 +62,6 @@ In addition to the standard SublimeLinter settings, `SublimeLinter-gcc` provides
 | include_dirs | A list of directories to be added to the header search paths (`-I` is not needed). |
 | extra_flags | A list of extra flags to pass to the compiler. These should be used carefully, as they may cause linting to fail. |
 
-- All settings above could be `C` or `C++` specific as well.
-  To do that, simply add `c_` or `c++_` prefix to a setting's key.
-
 - For project-specific settings, `${project_folder}` can be used to specify relative path.
 
 Here is an example settings:
@@ -75,19 +72,23 @@ Here is an example settings:
     {
         "gcc": {
             "disable": false,
-            // C-specific settings
-            "c_executable": "gcc",
-            "c_extra_flags": [
+            "executable": "gcc",
+            "extra_flags": [
                 "-fsyntax-only",
                 "-std=c90",
             ],
-            // C++-specific settings
-            "c++_executable": "g++",
-            "c++_extra_flags": [
+            "include_dirs": [
+                "${project_folder}/include",
+                "/usr/local/include",
+            ],
+        },
+        "gcc++": {
+            "disable": false,
+            "executable": "g++",
+            "extra_flags": [
                 "-fsyntax-only",
                 "-std=c++11",
             ],
-            // include_dirs for both C and C++
             "include_dirs": [
                 "${project_folder}/include",
                 "/usr/local/include",

--- a/linter.py
+++ b/linter.py
@@ -3,7 +3,7 @@
 # Linter for SublimeLinter4, a code checking framework for Sublime Text 3
 #
 # Written by Jack Cherng
-# Copyright (c) 2017-2019 jfcherng
+# Copyright (c) 2017-2018 jfcherng
 #
 # License: MIT
 #
@@ -23,20 +23,7 @@ def get_SL_version():
     Return the major version number of SublimeLinter.
     """
 
-    return getattr(SublimeLinter.lint, "VERSION", 3)
-
-
-def get_syntax():
-    """
-    Return the lowercase syntax name of the current view.
-    """
-
-    view = sublime.active_window().active_view()
-
-    if get_SL_version() == 3:
-        return persist.get_syntax(view)
-    else:
-        return util.get_syntax(view)
+    return getattr(SublimeLinter.lint, 'VERSION', 3)
 
 
 def get_project_folder():
@@ -50,7 +37,7 @@ def get_project_folder():
     if not project_file:
         project_file = sublime.active_window().active_view().file_name()
 
-    return os.path.dirname(project_file) if project_file else "."
+    return os.path.dirname(project_file) if project_file else '.'
 
 
 def apply_template(s):
@@ -58,83 +45,61 @@ def apply_template(s):
     Return a string with variables inside it gets interpreted.
     """
 
-    # fmt: off
     mapping = {
-        "project_folder": get_project_folder(),
+        'project_folder': get_project_folder(),
     }
-    # fmt: on
 
     return string.Template(s).safe_substitute(mapping)
 
+
+def get_executable():
+  if get_SL_version() == 3:
+    # Note: This is a dirty hack to use a dynamical "executable" for SL3.
+    #
+    # If "executable" is not found here, this linter just won't be activated.
+    # The following if-branch makes sure an "executable" could be found.
+    # The actual "executable" is in the returned command from cmd(self).
+    #
+    # @see https://git.io/vb5Nb
+    return 'cmd' if sublime.platform() == 'windows' else 'cat'
+  return 'gcc'
 
 class Gcc(Linter):
     """
     Provides an interface to gcc/g++.
     """
-
-    # fmt: off
-    c_syntaxes = {
-        'c',
-        'c99',
-        'c11',
-        'c improved',
-    }
-
-    cpp_syntaxes = {
-        'c++',
-        'c++11',
-    }
-
     common_flags = [
         '-c',
         '-Wall',
         '-O0',
+        '-x c',
     ]
 
-    defaults = {
-        'executable': 'gcc',
+    default_settings = {
+        'executable': get_executable(),
         'extra_flags': [],
         'include_dirs': [],
     }
-    # fmt: on
 
-    if sublime.platform() == "windows":
-        garbage_file = os.path.join(tempfile.gettempdir(), "SublimeLinter-gcc.o")
+    defaults = {
+        'selector': "source.c",
+    }
+
+    if sublime.platform() == 'windows':
+        garbage_file = os.path.join(tempfile.gettempdir(), 'SublimeLinter-gcc.o')
     else:
-        garbage_file = "/dev/null"
+        garbage_file = '/dev/null'
 
-    cmd_template = " ".join(
-        [
-            "{executable}",
-            "{common_flags}",
-            "{extra_flags}",
-            "{include_dirs}",
-            "-x {c_or_cpp}",
-            "-o {garbage_file}",
-            "-",
-        ]
-    )
+    cmd_template = '{executable} {common_flags} {extra_flags} {include_dirs} -o {garbage_file} -'
 
     # SublimeLinter capture settings
-    executable = None
     on_stderr = None  # handle stderr via split_match
     multiline = True
-    syntax = list(c_syntaxes | cpp_syntaxes)
     regex = (
-        r"<stdin>:(?P<line>\d+):((?P<col>\d+):)?\s*"
-        r".*?((?P<error>error)|(?P<warning>warning|note)):\s*"
-        r"(?P<message>.+)"
+        r'<stdin>:(?P<line>\d+):((?P<col>\d+):)?\s*'
+        r'.*?((?P<error>error)|(?P<warning>warning|note)):\s*'
+        r'(?P<message>.+)'
     )
-
-    if get_SL_version() == 3:
-        # Note: This is a dirty hack to use a dynamical "executable" for SL3.
-        #
-        # If "executable" is not found here, this linter just won't be activated.
-        # The following if-branch makes sure an "executable" could be found.
-        # The actual "executable" is in the returned command from cmd(self).
-        #
-        # @see https://git.io/vb5Nb
-        executable = "cmd" if sublime.platform() == "windows" else "cat"
 
     def cmd(self):
         """
@@ -143,47 +108,34 @@ class Gcc(Linter):
         We override this method, so we can change executable, add extra flags
         and include directories basing on settings.
         """
-
-        c_or_cpp = "c" if get_syntax() in self.c_syntaxes else "c++"
-        settings = self.get_syntax_specific_settings(c_or_cpp)
-
+        extra_flags = self.settings['extra_flags']
+        if isinstance(extra_flags, list):
+          extra_flags = ' '.join(extra_flags)
         return self.cmd_template.format(
-            executable=settings["executable"],
-            common_flags=" ".join(self.common_flags),
-            extra_flags=apply_template(" ".join(settings["extra_flags"])),
-            include_dirs=apply_template(
-                " ".join(
-                    {"-I" + shlex.quote(include_dir) for include_dir in settings["include_dirs"]}
-                )
-            ),
-            c_or_cpp=c_or_cpp,
-            garbage_file=shlex.quote(self.garbage_file),
+            executable = self.settings['executable'],
+            common_flags = ' '.join(self.common_flags),
+            extra_flags = apply_template(extra_flags),
+            include_dirs = apply_template(' '.join({
+                '-I' + shlex.quote(include_dir)
+                for include_dir in self.settings['include_dirs']
+            })),
+            garbage_file = shlex.quote(self.garbage_file),
         )
 
-    def get_syntax_specific_settings(self, c_or_cpp):
-        """
-        Return the syntax specific settings.
-        """
+class GccPlus(Gcc):
+    name = "gcc++"
+    is_cpp = True
 
-        settings = self.get_view_settings()
+    common_flags = [
+        '-c',
+        '-Wall',
+        '-O0',
+        '-x c++',
+    ]
 
-        ret = {
-            attr: settings.get(
-                "{}_{}".format(c_or_cpp, attr), settings.get(attr, self.defaults[attr])
-            )
-            for attr in self.defaults
-        }
-
-        # append the directory of the current file to the include directory
-        file_path = self.view.file_name()
-        if file_path:
-            ret["include_dirs"].append(os.path.dirname(file_path))
-
-        # just for BC, always convert "extra_flags" into a list
-        if isinstance(ret["extra_flags"], str):
-            ret["extra_flags"] = shlex.split(ret["extra_flags"])
-
-        return ret
+    defaults = {
+        'selector': "source.c++",
+    }
 
 
 class SublimeLinterGccRunTests(sublime_plugin.WindowCommand):

--- a/messages/update_message.md
+++ b/messages/update_message.md
@@ -2,6 +2,10 @@ SublimeLinter-gcc has been updated. To see the changelog, visit
 Preferences » Package Settings » SublimeLinter-gcc » Changelog
 
 
-## 1.3.9
+## 1.4.0
 
-- Fix a typo.
+- Make sure to update your configuration by pressing Meta+shift+P, <Preferences: SublimeLinter Settings>, and use
+gcc : { executable : 'gcc' },
+g++ : { executable : 'g++' }
+instead of
+gcc { c_executable : 'gcc', cpp_executable : 'g++' }


### PR DESCRIPTION
This changes the configuration, going from cpp_executable
to gcc.executable & g++.executable. This should allow cleaner
code than parsing the result of get_syntax imho